### PR TITLE
Load 'loading' image using protocol-relative paths

### DIFF
--- a/assets/javascripts/drawioEditor.js
+++ b/assets/javascripts/drawioEditor.js
@@ -1,7 +1,7 @@
 function editDiagram(image, resource, isDmsf, pageName) {
     var initial = image.getAttribute('src');
     
-    image.setAttribute('src', 'http://www.draw.io/images/ajax-loader.gif');
+    image.setAttribute('src', '//www.draw.io/images/ajax-loader.gif');
     
     var iframe = document.createElement('iframe');
     


### PR DESCRIPTION
When loading the ajax-loader image from a https site I am getting the following error message,  this switches to protocol-relative paths.

Mixed Content: The page at 'https://support.my-site.com/issues/9999' was loaded over HTTPS, but requested an insecure image 'http://www.draw.io/images/ajax-loader.gif'. This content should also be served over HTTPS.