### PR TITLE
Russian translation for redmine_drawio

### DIFF
--- a/assets/javascripts/lang/drawio_jstoolbar-en.js
+++ b/assets/javascripts/lang/drawio_jstoolbar-en.js
@@ -4,7 +4,7 @@ Drawio.strings['drawio_error_saving' ] = 'Error saving diagram:\n';
 Drawio.strings['drawio_http_401'     ] = 'Not authorized';
 Drawio.strings['drawio_http_404'     ] = 'Make sure WebDAV capabilities of DMSF module is enabled';
 Drawio.strings['drawio_http_409'     ] = 'Make sure the DMSF folder exists and is accessible';
-Drawio.strings['drawio_http_422'     ] = 'Diagram size to big: increase the attachment size in Redmine settings';
+Drawio.strings['drawio_http_422'     ] = 'Diagram size too big: increase the attachment size in Redmine settings';
 Drawio.strings['drawio_http_502'     ] = 'Make sure WebDAV capabilities of DMSF module is enabled in Read/Write mode';
 // CKEditor plugin messages
 Drawio.strings['drawio_cke_diagName'       ] = 'Diagram name';

--- a/assets/javascripts/lang/drawio_jstoolbar-ru.js
+++ b/assets/javascripts/lang/drawio_jstoolbar-ru.js
@@ -16,7 +16,7 @@ Drawio.strings['drawio_cke_dmsf_dlgtitle'  ] = 'Определить DMSF-диа
 Drawio.strings['drawio_cke_dmsf_btnlabel'  ] = 'Drawio DMSF-диаграмма';
 
 // Standard jstoolbar editor messages
-Drawio.strings['drawio_btn_ok'      ] = 'Вставить макросInsert macro';
+Drawio.strings['drawio_btn_ok'      ] = 'Вставить макрос';
 Drawio.strings['drawio_btn_cancel'  ] = 'Отмена';
 Drawio.strings['drawio_attach_title'] = 'Прикрепить к Drawio-диаграмме';
 Drawio.strings['drawio_dmsf_title'  ] = 'Использовать Drawio-диаграмму, сохраненную в DMSF-модуле';

--- a/assets/javascripts/lang/drawio_jstoolbar-ru.js
+++ b/assets/javascripts/lang/drawio_jstoolbar-ru.js
@@ -1,0 +1,22 @@
+// General messages
+Drawio.strings['drawio_updating_page'] = 'Обновление страницы';
+Drawio.strings['drawio_error_saving' ] = 'Ошибка при сохранении диаграммы:\n';
+Drawio.strings['drawio_http_401'     ] = 'Не авторизован';
+Drawio.strings['drawio_http_404'     ] = 'Убедитесь, что WebDAV для модуля DMSF включен';
+Drawio.strings['drawio_http_409'     ] = 'Убедитесь, что DMSF папка существует и доступна';
+Drawio.strings['drawio_http_422'     ] = 'Размер диаграммы слишком большой: увеличьте максимальный размер вложений в настройках Redmine';
+Drawio.strings['drawio_http_502'     ] = 'Убедитесь, что WebDAV для модуля DMSF включен в режиме чтения/записи';
+// CKEditor plugin messages
+Drawio.strings['drawio_cke_diagName'       ] = 'Название диаграммы';
+Drawio.strings['drawio_cke_diagType'       ] = 'Формат диаграммы';
+Drawio.strings['drawio_cke_size'           ] = 'Ширина (в пикселах)';
+Drawio.strings['drawio_cke_attach_dlgtitle'] = 'Определить прикрепленную диаграмму';
+Drawio.strings['drawio_cke_attach_btnlabel'] = 'Прикрепленная Drawio-диаграмма';
+Drawio.strings['drawio_cke_dmsf_dlgtitle'  ] = 'Определить DMSF-диаграмму';
+Drawio.strings['drawio_cke_dmsf_btnlabel'  ] = 'Drawio DMSF-диаграмма';
+
+// Standard jstoolbar editor messages
+Drawio.strings['drawio_btn_ok'      ] = 'Вставить макросInsert macro';
+Drawio.strings['drawio_btn_cancel'  ] = 'Отмена';
+Drawio.strings['drawio_attach_title'] = 'Прикрепить к Drawio-диаграмме';
+Drawio.strings['drawio_dmsf_title'  ] = 'Использовать Drawio-диаграмму, сохраненную в DMSF-модуле';

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,0 +1,10 @@
+# Russian strings go here for Rails i18n
+ru:
+  drawio_url: "URL сервиса Draw.io"
+  drawio_service_url_hint: "URL для вашей локальной установки сервиса; задайте как '//www.draw.io' для использования онлайн-сервиса"
+  drawio_mathjax: "Поддержка математики для SVG"
+  drawio_mathjax_hint: "Включить поддержку математических символов для SVG-диаграмм"
+  drawio_dlg_title: "Определить диаграмму"
+  drawio_dlg_diagName: "Название диаграммы"
+  drawio_dlg_diagType: "Формат диаграммы"
+  drawio_dlg_size: "Ширина"


### PR DESCRIPTION
Russian translation of ``assets/javascripts/lang/drawio_jstoolbar-en.js``, ``config/en.yml`` and small typo fixed in ``drawio_jstoolbar-en.js``