### PR TITLE
fix: usr: fix bug while saving diagram on page with non-ascii name

### DIFF
--- a/assets/javascripts/drawioEditor.js
+++ b/assets/javascripts/drawioEditor.js
@@ -199,7 +199,7 @@ function editDiagram(image, resource, isDmsf, pageName) {
     function saveAttachment(resource, imageData, type, pageName) {
         var pageUrl = window.location.pathname;
         
-        if(!pageUrl.match(pageName+'$'))
+        if(!pageUrl.match(encodeURIComponent(pageName)+'$'))
             pageUrl += '/'+pageName;
         
         function readWikiPage(uploadResponse) {


### PR DESCRIPTION
Fixed generating wrong URL when trying update attachments on a page.
This bug occurs on wiki-page that has pageName with non-ascii characters.

Resolves #42.

Signed-off-by: Anton Sergeev <Anton.Sergeev@elecard.ru>