### PR TITLE
Quick fix - Always display the last version of diagrams

### DIFF
--- a/lib/redmine_drawio/macros.rb
+++ b/lib/redmine_drawio/macros.rb
@@ -59,7 +59,7 @@ EOF
             container = obj
         end
         
-        attach = container.attachments.find_by_filename(filename)
+        attach = container.attachments.where(filename: filename).last
         return "Diagram attachment missing or isn't a text file".html_safe unless attach && attach.is_text?
         
         file = File.open(attach.diskfile)
@@ -133,7 +133,7 @@ EOF
         diagramName += ".png" if File.extname(diagramName.strip) == ""
         
         # Search attachment position
-        attach = container.attachments.find_by_filename(diagramName)
+        attach = container.attachments.where(filename: diagramName).last
         
         if canEdit
             # Diagram and document are editable


### PR DESCRIPTION
If several attachments have the same name, we should display the last version of the diagram.

**Why is it important ?**
Currently, if we edit the same diagram several times, **without** reloading the wiki page, each saved diagram will have the same name (the version in the filename is only incremented when we reload the page). It means that when we finally reload the page, the diagram displayed is the first found with this name and not the more recent.