### PR TITLE
Avoid errors with encoding characters in URL

### DIFF
--- a/assets/javascripts/drawioEditor.js
+++ b/assets/javascripts/drawioEditor.js
@@ -201,8 +201,9 @@ function editDiagram(image, resource, isDmsf, pageName) {
      */             
     function saveAttachment(resource, imageData, type, pageName) {
         var pageUrl = window.location.pathname;
-        
-        if(!pageUrl.match(encodeURIComponent(pageName)+'$'))
+
+        var encodedPageName = new RegExp(encodeURIComponent(pageName)+'$', 'i');
+        if(!pageUrl.match(encodedPageName))
             pageUrl += '/'+pageName;
         
         function readWikiPage(uploadResponse) {


### PR DESCRIPTION
Hello.
We have found a bug when a wiki URL contains encoded characters, like single quotes.
Char codes may use lowercase or uppercase characters and it may cause problems when saving diagrams.
The regex should be case-insensitive.
Thanks

```
pageUrl = "/projects/project_slug/wiki/Plan_d%e2%80%99architecture" (window.location.pathname)
pageUrl.match("Plan_d%E2%80%99architecture"+'$') --> FALSE
pageUrl.match("Plan_d%e2%80%99architecture"+'$') --> TRUE
```

