### PR TITLE
Load MathJax through CDN if custom url is an empty string

### DIFF
--- a/lib/redmine_drawio/hooks/view_hooks.rb
+++ b/lib/redmine_drawio/hooks/view_hooks.rb
@@ -111,7 +111,7 @@ module RedmineDrawio
         
         def mathjax_url
             url = Setting.plugin_redmine_drawio['drawio_mathjax_url']
-            url = '//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js' unless url
+            url = '//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js' unless url.present?
             url
         end
 


### PR DESCRIPTION
If we set a custom URL to MathJax library, and later remove it, the url variable is then an empty string, which return true in ruby.
In this case, we should load the MathJax library through CDN.

```
url = ""
url => true
url.present? => false
```