### PR TITLE
With commit https://github.com/mikitex70/redmine_drawio/commit/e7b6b0…

### DIFF
--- a/lib/redmine_drawio/hooks/view_hooks.rb
+++ b/lib/redmine_drawio/hooks/view_hooks.rb
@@ -5,7 +5,7 @@ require 'base64'
 module RedmineDrawio
 
     class ViewLayoutsBaseHtmlHeadHook < Redmine::Hook::ViewListener
-        
+
         # This method will add the necessary CSS and JS scripts to the page header.
         # The scripts are loaded before the 'jstoolbar-textile.min.js' is loaded so
         # the toolbar cannot be patched.
@@ -14,7 +14,7 @@ module RedmineDrawio
         # object.
         def view_layouts_base_html_head(context={})
             header = ''
-            
+
             if Setting.plugin_redmine_drawio['drawio_mathjax']
                 # Some MathJax tuning:
                 # * set regexp for classes to ignore, for to no apply MathJax to wrong elements
@@ -38,15 +38,15 @@ module RedmineDrawio
                 header << inline
                 header << javascript_include_tag("#{mathjax_url}?config=TeX-MML-AM_HTMLorMML")
             end
-            
+
             return header unless editable?(context)
-            
+
             if Setting.plugin_redmine_drawio['drawio_service_url'].to_s.strip.empty?
                 drawio_url = '//embed.diagrams.net'
             else
                 drawio_url = Setting.plugin_redmine_drawio['drawio_service_url']
             end
-            
+
             inline = <<-EOF
                 <script type=\"text/javascript\">//<![CDATA[
                     var Drawio = {
@@ -60,20 +60,20 @@ module RedmineDrawio
                     };
                 //]]></script>
             EOF
-            
+
             header << inline
             header << stylesheet_link_tag("drawioEditor.css"  , :plugin => "redmine_drawio", :media => "screen")
             header << javascript_include_tag("encoding-indexes.js", :plugin => "redmine_drawio")
-            header << javascript_include_tag("encoding.min.js", :plugin => "redmine_drawio")
+            header << javascript_include_tag("encoding.js", :plugin => "redmine_drawio")
             header << javascript_include_tag("drawioEditor.js", :plugin => "redmine_drawio")
             header << javascript_include_tag("lang/drawio_jstoolbar-en.js", :plugin => "redmine_drawio")
             header << javascript_include_tag("lang/drawio_jstoolbar-#{current_language.to_s.downcase}.js", :plugin => "redmine_drawio") if lang_supported? current_language.to_s.downcase
             header << javascript_include_tag("drawio_jstoolbar.js", :plugin => "redmine_drawio") unless ckeditor_enabled?
             header
         end
-        
+
         private
-        
+
         def editable?(context)
             return false unless context[:controller]
             return true  if context[:controller].is_a?(WikiController) && User.current.allowed_to?(:edit_wiki_pages, context[:project])
@@ -86,7 +86,7 @@ module RedmineDrawio
                 context[:issue].editable?(User.current)
             end
         end
-        
+
         # Returns the context path of Redmine installation (usually '/' or '/redmine/').
         def redmine_url
             rootUrl = ActionController::Base.relative_url_root
@@ -95,26 +95,26 @@ module RedmineDrawio
 
             return '/'
         end
-        
+
         def dmsf_enabled?(context)
             return false unless Redmine::Plugin.installed? :redmine_dmsf
             return false unless context[:project] && context[:project].module_enabled?('dmsf')
             true
         end
-        
+
         def ckeditor_enabled?
             Setting.text_formatting == "CKEditor"
         end
-        
+
         def easyredmine?
             Redmine::Plugin.installed?(:easy_redmine)
         end
-        
+
         def lang_supported? lang
             return false if lang == 'en' # English is always loaded, avoid double load
             File.exist? "#{File.expand_path('../../../../assets/javascripts/lang', __FILE__)}/drawio_jstoolbar-#{lang}.js"
         end
-        
+
         def mathjax_url
             url = Setting.plugin_redmine_drawio['drawio_mathjax_url']
             url = '//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js' unless url.present?
@@ -122,5 +122,5 @@ module RedmineDrawio
         end
 
     end
-    
+
 end


### PR DESCRIPTION
With https://github.com/mikitex70/redmine_drawio/commit/e7b6b0bbe1a45377a098acb9e34566bb13ea07a7#diff-f7a7e3f316fb458595a70a9ee3a1e01d00a263ac3930f67456df9f400e606180 encoding.js was changed to encoding.min.js - but the file is still called encoding.js. This PR changes the view_hook include back to encoding.js