### PR TITLE
Fixed usage of drawio_svg_enabled setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ bower.json
 # Ignore Byebug command history file.
 .byebug_history
 .directory
+
+# Ignore vscode history
+.history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 
+## unreleased
+
+### Fix
+
+* Fixed usage of drawio_svg_enabled setting
+
+  If svg is disabled the corresponding checkbox 
+  in _marcro_dialog.html.erb won't be displayed 
+
 ## v1.2.1 (2022-01-05)
 
 ### Fix

--- a/app/views/redmine_drawio/_macro_dialog.html.erb
+++ b/app/views/redmine_drawio/_macro_dialog.html.erb
@@ -9,6 +9,7 @@
         <p>
           <label for="drawio_diagType"><%= l(:drawio_dlg_diagType) %></label>
           <input type="radio" name="drawio_diagType" value="png" checked="checked"/>PNG
+
           <% if svg_enabled %>
           <input type="radio" name="drawio_diagType" value="svg" style="margin-left:1em"/>SVG
           <% end %>

--- a/app/views/settings/_drawio_settings.html.erb
+++ b/app/views/settings/_drawio_settings.html.erb
@@ -3,7 +3,7 @@
   <label><%= l(:drawio_url) %></label>
   <%= text_field_tag 'settings[drawio_service_url]', @settings['drawio_service_url'], size: 60 %><br/>
   <em><%= l(:drawio_service_url_hint) %></em><br/>
-  
+
   <label><%= l(:drawio_svg_enabled) %></label>
   <%= check_box_tag 'settings[drawio_svg_enabled]', true, @settings['drawio_svg_enabled'] %><br/>
   <em><%= l(:drawio_svg_enabled_hint) %></em><br/>

--- a/lib/redmine_drawio.rb
+++ b/lib/redmine_drawio.rb
@@ -7,6 +7,7 @@ require 'redmine_drawio/patches/string_patch'
 
 # Helpers
 require 'redmine_drawio/helpers/drawio_dmsf_helper'
+require 'redmine_drawio/helpers/drawio_settings_helper'
 require 'redmine_drawio/helpers/textile_helper'
 require 'redmine_drawio/helpers/markdown_helper'
 

--- a/lib/redmine_drawio/helpers/drawio_settings_helper.rb
+++ b/lib/redmine_drawio/helpers/drawio_settings_helper.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Copyright (C) 2022 Liane Hampe <liaham@xmera.de>, xmera.
+
+##
+# Helps to use the plugin settings throughout the code.
+#
+# @note The table check is necessary for running tests since the table is not
+#   available when loading this code first.
+#
+module DrawioSettingsHelper
+  def self.svg_enabled?
+    return false unless ActiveRecord::Base.connection.data_source_exists? 'settings'
+
+    Setting[:plugin_redmine_drawio]['drawio_svg_enabled'].present? ? true : false
+  end
+end

--- a/lib/redmine_drawio/hooks/macro_dialog.rb
+++ b/lib/redmine_drawio/hooks/macro_dialog.rb
@@ -1,10 +1,12 @@
 # encoding: UTF-8
 
 class RedmineDrawioHookListener < Redmine::Hook::ViewListener
-    svg_enabled = Setting[:plugin_redmine_drawio]['drawio_svg_enabled']
-    svg_enabled = true if svg_enabled.nil?
-    
-    render_on :view_layouts_base_body_bottom, :partial => "redmine_drawio/macro_dialog", :locals => {
-        svg_enabled: svg_enabled
-    }
+    include DrawioSettingsHelper
+
+    def view_layouts_base_body_bottom(context = {})
+        html = context[:controller].send(:render_to_string,
+                                         { partial: 'redmine_drawio/macro_dialog',
+                                           locals: { svg_enabled: svg_enabled? } })
+        html.html_safe
+    end
 end

--- a/lib/redmine_drawio/macros.rb
+++ b/lib/redmine_drawio/macros.rb
@@ -444,7 +444,5 @@ def js_safe(string)
 end
 
 def svg_enabled?
-    enabled = Setting.plugin_redmine_drawio['drawio_svg_enabled']
-    enabled = true if enabled.nil?
-    enabled
+    DrawioSettingsHelper.svg_enabled?
 end

--- a/test/authenticate_user.rb
+++ b/test/authenticate_user.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Copyright (C) 2022 Liane Hampe <liaham@xmera.de>, xmera.
+
+module RedmineDrawio
+  ##
+  # Provide user login test
+  #
+  module AuthenticateUser
+    module_function
+
+    def log_user(login, password)
+      login_page
+      log_user_in(login, password)
+      assert_equal login, User.find(user_session_id).login
+    end
+
+    private
+
+    def login_page
+      User.anonymous
+      get '/login'
+      assert_nil user_session_id
+      assert_response :success
+    end
+
+    def user_session_id
+      session[:user_id]
+    end
+
+    def log_user_in(login, password)
+      post '/login', params: {
+        username: login,
+        password: password
+      }
+    end
+  end
+end

--- a/test/integration/macro_dialog_test.rb
+++ b/test/integration/macro_dialog_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Copyright (C) 2022 Liane Hampe <liaham@xmera.de>, xmera.
+
+require File.expand_path('test_helper', File.dirname(__dir__))
+require File.expand_path('authenticate_user', File.dirname(__dir__))
+require File.expand_path('load_fixtures', File.dirname(__dir__))
+require File.expand_path('with_drawio_settings', File.dirname(__dir__))
+
+class MacroDialogTest < ActionDispatch::IntegrationTest
+  include RedmineDrawio::AuthenticateUser
+  include RedmineDrawio::LoadFixtures
+  include RedmineDrawio::WithDrawioSettings
+
+  fixtures :users, :email_addresses, :roles
+
+  def teardown
+    Setting.plugin_redmine_drawio = { drawio_svg_enabled: nil }
+  end
+
+  test 'render macro dialog' do
+    render_marcro_dialog
+    assert_select '#dlg_redmine_drawio'
+  end
+
+  test 'render macro diaglog without svg' do
+    with_settings(redmine_drawio({ drawio_svg_enabled: false })) do
+      render_marcro_dialog
+      assert_select 'input[value=?]', 'svg', 0
+    end
+  end
+
+  test 'render macro diaglog with svg' do
+    with_settings(redmine_drawio({ drawio_svg_enabled: true })) do
+      render_marcro_dialog
+      assert_select 'input[value=?]', 'svg'
+    end
+  end
+
+  private
+
+  def render_marcro_dialog
+    log_user('admin', 'admin')
+    get '/settings/plugin/redmine_drawio'
+    assert_response :success
+  end
+end

--- a/test/load_fixtures.rb
+++ b/test/load_fixtures.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Copyright (C) 2022 Liane Hampe <liaham@xmera.de>, xmera.
+
+module RedmineDrawio
+  ##
+  # Redmine won't load plugin fixtures out-of-the-box.
+  # This module loads first the plugin fixtures and then Redmine fixtures
+  # if the listed file does not exist in the plugin's fixture directory.
+  #
+  module LoadFixtures
+    class << self
+      def fixtures(*table_names)
+        dir = File.join(File.dirname(__FILE__), '/fixtures')
+        table_names.each do |file|
+          create_fixtures(dir, file) if File.exist?("#{dir}/#{file}.yml")
+        end
+        super(table_names)
+      end
+
+      private
+
+      def create_fixtures(dir, file)
+        ActiveRecord::FixtureSet.create_fixtures(dir, file)
+      end
+    end
+  end
+end

--- a/test/unit/drawio_settings_helper_test.rb
+++ b/test/unit/drawio_settings_helper_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Copyright (C) 2022 Liane Hampe <liaham@xmera.de>, xmera.
+
+require File.expand_path('test_helper', File.dirname(__dir__))
+require File.expand_path('with_drawio_settings', File.dirname(__dir__))
+
+class DrawioSettingsHelperTest < ActiveSupport::TestCase
+  include DrawioSettingsHelper
+  include RedmineDrawio::WithDrawioSettings
+
+  def teardown
+    Setting.plugin_redmine_drawio = { drawio_svg_enabled: nil }
+  end
+
+  def test_svg_disabled
+    with_settings(redmine_drawio({ drawio_svg_enabled: false })) do 
+      assert_not svg_enabled?
+    end
+  end
+
+  def test_svg_enabled
+    with_settings(redmine_drawio({ drawio_svg_enabled: true })) do 
+      assert svg_enabled?
+    end
+  end
+end

--- a/test/with_drawio_settings.rb
+++ b/test/with_drawio_settings.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Copyright (C) 2022 Liane Hampe <liaham@xmera.de>, xmera.
+
+module RedmineDrawio
+  module WithDrawioSettings
+    def redmine_drawio(**attrs)
+      { plugin_redmine_drawio: attrs }.with_indifferent_access
+    end
+  end
+end


### PR DESCRIPTION
If svg is disabled in plugin settings the corresponding checkbox in _marcro_dialog.html.erb won't be displayed anymore. Before that fix it was always displayed.

Adds also tests for this fix!  Furthermore, a check for the settings table is added in DrawioSettingsHelper.svg_enabled? since the table is not immediately available when loading the code for tests.

