### PR TITLE
fix_for_failing_redmine_api_key_test

### DIFF
--- a/app/views/redmine_drawio/hooks/_api_not_enabled_warning.html.erb
+++ b/app/views/redmine_drawio/hooks/_api_not_enabled_warning.html.erb
@@ -1,0 +1,1 @@
+<% flash[:warning] = l(:drawio_warning_api_needs_to_be_enabled) %>

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -18,3 +18,4 @@ da:
   drawio_dlg_page: "Initial page"
   drawio_dlg_hiligh: "Hyperlinks color"
   drawio_dlg_zoom: "Zoom controls"
+  drawio_warning_api_needs_to_be_enabled: For saving drawio diagrams you need to enable the REST API in Administration -> Configuration -> API.

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -18,3 +18,4 @@ de:
   drawio_dlg_page: "Initial page"
   drawio_dlg_hiligh: "Hyperlinks color"
   drawio_dlg_zoom: "Zoom controls"
+  drawio_warning_api_needs_to_be_enabled: Um drawio Diagramme speichern zu können, muss die REST API unter Administration -> Konfiguration -> API aktiviert werden.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,3 +18,4 @@ en:
   drawio_dlg_page: "Initial page"
   drawio_dlg_hiligh: "Hyperlinks color"
   drawio_dlg_zoom: "Zoom controls"
+  drawio_warning_api_needs_to_be_enabled: For saving drawio diagrams you need to enable the REST API in Administration -> Configuration -> API.

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -18,4 +18,4 @@ it:
   drawio_dlg_page: "Pagina iniziale"
   drawio_dlg_hiligh: "Colore degli hyperlink"
   drawio_dlg_zoom: "Controlli zoom"
-  
+  drawio_warning_api_needs_to_be_enabled: For saving drawio diagrams you need to enable the REST API in Administration -> Configuration -> API.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -18,3 +18,4 @@ ja:
   drawio_dlg_page: "Initial page"
   drawio_dlg_hiligh: "Hyperlinks color"
   drawio_dlg_zoom: "Zoom controls"
+  drawio_warning_api_needs_to_be_enabled: For saving drawio diagrams you need to enable the REST API in Administration -> Configuration -> API.

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -18,3 +18,4 @@ ko:
   drawio_dlg_page: "Initial page"
   drawio_dlg_hiligh: "Hyperlinks color"
   drawio_dlg_zoom: "Zoom controls"
+  drawio_warning_api_needs_to_be_enabled: For saving drawio diagrams you need to enable the REST API in Administration -> Configuration -> API.

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -18,3 +18,4 @@ ru:
   drawio_dlg_page: "Initial page"
   drawio_dlg_hiligh: "Hyperlinks color"
   drawio_dlg_zoom: "Zoom controls"
+  drawio_warning_api_needs_to_be_enabled: For saving drawio diagrams you need to enable the REST API in Administration -> Configuration -> API.

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -16,3 +16,4 @@ zh-TW:
   drawio_dlg_page: "Initial page"
   drawio_dlg_hiligh: "Hyperlinks color"
   drawio_dlg_zoom: "Zoom controls"
+  drawio_warning_api_needs_to_be_enabled: For saving drawio diagrams you need to enable the REST API in Administration -> Configuration -> API.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -18,3 +18,4 @@ zh:
   drawio_dlg_page: "Initial page"
   drawio_dlg_hiligh: "Hyperlinks color"
   drawio_dlg_zoom: "Zoom controls"
+  drawio_warning_api_needs_to_be_enabled: For saving drawio diagrams you need to enable the REST API in Administration -> Configuration -> API.

--- a/lib/redmine_drawio/hooks/view_hooks.rb
+++ b/lib/redmine_drawio/hooks/view_hooks.rb
@@ -4,6 +4,14 @@ require 'base64'
 
 module RedmineDrawio
 
+    class ViewLayoutsBaseBodyTop < Redmine::Hook::ViewListener
+        def view_layouts_base_body_top(context = {})
+            return unless User.current.admin? && !Setting.rest_api_enabled?
+
+            context[:controller].send(:render_to_string, { partial: 'redmine_drawio/hooks/api_not_enabled_warning' })
+        end
+    end
+
     class ViewLayoutsBaseHtmlHeadHook < Redmine::Hook::ViewListener
         
         # This method will add the necessary CSS and JS scripts to the page header.
@@ -63,7 +71,7 @@ module RedmineDrawio
                     var Drawio = {
                       settings: {
                         redmineUrl: '#{redmine_url}',
-                        hashCode  : '#{Base64.encode64(User.current.api_key).gsub(/\n/, '').reverse!}',
+                        hashCode  : '#{hash_code}',
                         drawioUrl : '#{drawio_url}',
                         DMSF      : #{dmsf_enabled? context},
                         isEasyRedmine: #{easyredmine?}
@@ -132,6 +140,11 @@ module RedmineDrawio
             url
         end
 
+        def hash_code
+            return '' unless Setting.sys_api_enabled?
+
+            Base64.encode64(User.current.api_key).gsub(/\n/, '').reverse!
+        end
     end
     
 end

--- a/test/integration/view_hooks_test.rb
+++ b/test/integration/view_hooks_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Copyright (C) 2022 Liane Hampe <liaham@xmera.de>, xmera.
+
+require File.expand_path('test_helper', File.dirname(__dir__))
+require File.expand_path('authenticate_user', File.dirname(__dir__))
+require File.expand_path('load_fixtures', File.dirname(__dir__))
+require File.expand_path('with_drawio_settings', File.dirname(__dir__))
+
+class ViewHooksTest < ActionDispatch::IntegrationTest
+  include Redmine::I18n
+  include RedmineDrawio::AuthenticateUser
+  include RedmineDrawio::LoadFixtures
+  include RedmineDrawio::WithDrawioSettings
+
+  fixtures :users, :email_addresses, :roles
+
+  def teardown
+    Setting.rest_api_enabled = nil
+  end
+
+  test 'render warning_api_needs_to_be_enabled when api is disabled' do
+    render_view_hooks
+    assert_select '#flash_warning', text: l(:drawio_warning_api_needs_to_be_enabled)
+  end
+
+  test 'do not render warning_api_needs_to_be_enabled when api is enabled' do
+    render_view_hooks(rest_api_enabled: '1')
+    assert_select '#flash_warning', 0
+  end
+
+  private
+
+  def render_view_hooks(rest_api_enabled: '0')
+    Setting.rest_api_enabled = rest_api_enabled
+    log_user('admin', 'admin')
+    get '/'
+    assert_response :success
+  end
+end


### PR DESCRIPTION
Hi @mikitex70,

during redmine test with redmine_drawio plugin installed I recognized a failing redmine test since redmine_drawio creates by 
default an api key for the current user even if the api is disabled. This will happen in RedmineDrawio::ViewLayoutsBaseHtmlHeadHook when providing the hash code. 

In order to fix that redmine test failure I created this pull request which provides the api key only if the api is enabled. Furthermore, it will render a warning for the administrator if the api is not enabled.

And of course, I added some tests. :)

Please let me know if there could be done something better.

Best Regards,
liaham

