### PR TITLE
Bug fix/missing common mark support

### DIFF
--- a/lib/redmine_drawio.rb
+++ b/lib/redmine_drawio.rb
@@ -7,6 +7,7 @@ require File.expand_path('../redmine_drawio/patches/string_patch', __FILE__)
 require File.expand_path('../redmine_drawio/patches/rbpdf_patch', __FILE__)
 
 # Helpers
+require File.expand_path('../redmine_drawio/helpers/common_mark_helper', __FILE__)
 require File.expand_path('../redmine_drawio/helpers/drawio_dmsf_helper', __FILE__)
 require File.expand_path('../redmine_drawio/helpers/drawio_settings_helper', __FILE__)
 require File.expand_path('../redmine_drawio/helpers/textile_helper', __FILE__)

--- a/test/integration/macro_dialog_test.rb
+++ b/test/integration/macro_dialog_test.rb
@@ -25,14 +25,14 @@ module RedmineDrawio
     end
 
     test 'render macro diaglog without svg' do
-      with_settings(redmine_drawio({ drawio_svg_enabled: false })) do
+      with_settings(redmine_drawio(**{ drawio_svg_enabled: false })) do
         render_marcro_dialog
         assert_select 'input[value=?]', 'svg', 0
       end
     end
 
     test 'render macro diaglog with svg' do
-      with_settings(redmine_drawio({ drawio_svg_enabled: true })) do
+      with_settings(redmine_drawio(**{ drawio_svg_enabled: true })) do
         render_marcro_dialog
         assert_select 'input[value=?]', 'svg'
       end

--- a/test/unit/drawio_settings_helper_test.rb
+++ b/test/unit/drawio_settings_helper_test.rb
@@ -14,13 +14,13 @@ module RedmineDrawio
     end
 
     def test_svg_disabled
-      with_settings(redmine_drawio({ drawio_svg_enabled: false })) do
+      with_settings(redmine_drawio(**{ drawio_svg_enabled: false })) do
         assert_not svg_enabled?
       end
     end
 
     def test_svg_enabled
-      with_settings(redmine_drawio({ drawio_svg_enabled: true })) do
+      with_settings(redmine_drawio(**{ drawio_svg_enabled: true })) do
         assert svg_enabled?
       end
     end


### PR DESCRIPTION
Hi @mikitex70,

I tested redmine_drawio with common mark editor but missed the drawio wikitool bar buttons. 

The problem is solved by adding your 'common_mark_helper.rb' to 'lib/redmine_drawio.rb'.  Additionally, I fixed some tests to be compatible with Ruby 3.x and 2.7.x.

Best Regards,
@liaham 