### PR TITLE
Upstream/removes mathjax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Changelog
 
-
 ## v1.4.9 (2024-11-17)
 
 ### Changes

--- a/app/views/settings/_drawio_settings.html.erb
+++ b/app/views/settings/_drawio_settings.html.erb
@@ -8,13 +8,4 @@
   <label><%= l(:drawio_svg_enabled) %></label>
   <%= check_box_tag 'settings[drawio_svg_enabled]', true, @settings['drawio_svg_enabled'] %><br/>
   <em><%= l(:drawio_svg_enabled_hint) %></em><br/>
-  
-  <label><%= l(:drawio_mathjax) %></label>
-  <%= check_box_tag 'settings[drawio_mathjax]', true, @settings['drawio_mathjax'] %><br/>
-  <em><%= l(:drawio_mathjax_hint) %></em><br/>
-  
-  <label><%= l(:drawio_mathjax_url) %></label>
-  <%= text_field_tag 'settings[drawio_mathjax_url]', @settings['drawio_mathjax_url'], size: 60, readonly: @settings['drawio_mathjax'] != 'true', class: 'drawio' %><br/>
-  <em><%= l(:drawio_mathjax_url_hint, value: DrawioSettings.defaults['drawio_mathjax_url']) %></em>
-  <%= javascript_include_tag "drawio_settings.js", :plugin => "redmine_drawio"%>
 </p>

--- a/init.rb
+++ b/init.rb
@@ -12,8 +12,6 @@ Redmine::Plugin.register :redmine_drawio do
 
   settings(partial: 'settings/drawio_settings',
            default: { 'drawio_service_url' => '//embed.diagrams.net',
-                      'drawio_mathjax'     => false,
-                      'drawio_mathjax_url' => '//cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.2/es5/tex-mml-chtml.js',
                       'drawio_svg_enabled' => false })
 
   should_be_disabled false if Redmine::Plugin.installed?(:easy_extensions)

--- a/lib/redmine_drawio/hooks/view_hooks.rb
+++ b/lib/redmine_drawio/hooks/view_hooks.rb
@@ -34,30 +34,6 @@ module RedmineDrawio
                     //]]</script>
                 EOF
 
-                if DrawioSettings['drawio_mathjax']
-                    # Some MathJax tuning:
-                    # * set regexp for classes to ignore, for to no apply MathJax to wrong elements
-                    # * MathJax context menu (enabled, maybe is better to disable it?)
-                    inline = <<-EOF
-                    <script type="text/x-mathjax-config">//<![CDATA[
-                    MathJax.Hub.Config({
-                        /*menuSettings: {
-                        context: "Browser"
-                        },*/
-                        tex2jax: {
-                        //inlineMath: [['$', '$'], ['\\(', '\\)']],
-                          ignoreClass: "wiki-class-no-mathjax|no-mathjax|error|warning|notice"
-                        },
-                        asciimath2jax: {
-                          ignoreClass: "wiki-class-no-mathjax|no-mathjax|error|warning|notice"
-                        }
-                    });
-                    //]]</script>
-                    EOF
-                    header << inline
-                    header << javascript_include_tag("#{mathjax_url}?config=TeX-MML-AM_HTMLorMML")
-                end
-
                 return header unless editable?(context)
 
                 inline = <<-EOF

--- a/test/unit/drawio_settings_test.rb
+++ b/test/unit/drawio_settings_test.rb
@@ -11,8 +11,7 @@ module RedmineDrawio
 
     def teardown
       Setting.plugin_redmine_drawio = { drawio_svg_enabled: nil,
-                                        drawio_service_url: nil,
-                                        drawio_mathjax_url: nil }
+                                        drawio_service_url: nil }
       Setting.clear_cache
     end
 
@@ -32,19 +31,9 @@ module RedmineDrawio
       assert_equal '//embed.diagrams.net', DrawioSettings.drawio_url
     end
 
-    def test_default_drawio_mathjax_url
-      assert_equal '//cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.2/es5/tex-mml-chtml.js', DrawioSettings.mathjax_url
-    end
-
     def test_custom_drawio_service_url
       with_settings(redmine_drawio(**{ drawio_service_url: '//custom' })) do
         assert_equal '//custom', DrawioSettings.drawio_url
-      end
-    end
-
-    def test_custom_drawio_mathjax_url
-      with_settings(redmine_drawio(**{ drawio_mathjax_url: '//custom' })) do
-        assert_equal '//custom', DrawioSettings.mathjax_url
       end
     end
   end


### PR DESCRIPTION
This PR is repeated since it is not quite clear to me whether it was recognized by you because it was excluded by you in the last version.

Mathjax will be removed since it is included by drawio by default. Hence, no need to load it by this plugin.


