### PR TITLE
Upstream/support redmine 6

### DIFF
--- a/lib/redmine_drawio.rb
+++ b/lib/redmine_drawio.rb
@@ -10,7 +10,7 @@ require File.expand_path('../redmine_drawio/patches/rbpdf_patch', __FILE__)
 require File.expand_path('../redmine_drawio/helpers/common_mark_helper', __FILE__)
 require File.expand_path('../redmine_drawio/helpers/drawio_dmsf_helper', __FILE__)
 require File.expand_path('../redmine_drawio/helpers/textile_helper', __FILE__)
-require File.expand_path('../redmine_drawio/helpers/markdown_helper', __FILE__)
+require File.expand_path('../redmine_drawio/helpers/markdown_helper', __FILE__) if Redmine::VERSION::MAJOR < 6
 
 # Hooks
 require File.expand_path('../redmine_drawio/hooks/view_hooks', __FILE__)

--- a/lib/redmine_drawio/helpers/markdown_helper.rb
+++ b/lib/redmine_drawio/helpers/markdown_helper.rb
@@ -18,7 +18,7 @@ if Rails::VERSION::STRING < '5.0.0'
                 @heads_for_wiki_formatter_with_drawio_included = true
             end
         end
-        
+
         # alias_method_chain is deprecated in Rails 5: replaced with two alias_method
         # as a quick workaround. Using the 'prepend' method can generate an
         # 'stack level too deep' error in conjunction with other (non ported) plugins.
@@ -26,7 +26,7 @@ if Rails::VERSION::STRING < '5.0.0'
         alias_method :heads_for_wiki_formatter_without_drawio, :heads_for_wiki_formatter
         alias_method :heads_for_wiki_formatter, :heads_for_wiki_formatter_with_drawio
     end
-else
+elsif Redmine::VERSION::MAJOR < 6
     # Rails 5, use new `prepend` method
     module RedmineDrawio
         module Helpers
@@ -46,7 +46,7 @@ else
             end
         end
     end
-    
+
     module Redmine::WikiFormatting::Markdown::Helper
         prepend RedmineDrawio::Helpers::MarkdownHelper
     end

--- a/test/unit/drawio_settings_test.rb
+++ b/test/unit/drawio_settings_test.rb
@@ -9,6 +9,10 @@ module RedmineDrawio
   class DrawioSettingsTest < ActiveSupport::TestCase
     include RedmineDrawio::WithDrawioSettings
 
+    def setup
+      Setting.clear_cache
+    end
+
     def teardown
       Setting.plugin_redmine_drawio = { drawio_svg_enabled: nil,
                                         drawio_service_url: nil }

--- a/test/unit/lib/redmine_drawio/drawio_macros_test.rb
+++ b/test/unit/lib/redmine_drawio/drawio_macros_test.rb
@@ -27,7 +27,7 @@ module RedmineDrawio
              :custom_fields, :custom_fields_projects, :custom_fields_trackers, :custom_values,
              :time_entries
 
-    def setup 
+    def setup
       @jsmith = User.find 2
       @manager_role = Role.find_by(name: 'Manager')
       @manager_role.add_permission! :view_dmsf_files
@@ -38,9 +38,9 @@ module RedmineDrawio
       default_url_options[:host] = 'http://example.com'
     end
 
-    def test_macro_drawio_deprecated 
+    def test_macro_drawio_deprecated
       text = textilizable("{{drawio(new-drawing.xml, hilight=#0000ff)}}")
-      assert_equal "<p>«The drawio macro is deprecated, use the drawio_attach macro instead»</p>", text 
+      assert_equal "<p>«The drawio macro is deprecated, use the drawio_attach macro instead»</p>", text
     end
 
     def test_macro_drawio_attach_unsaved
@@ -49,16 +49,18 @@ module RedmineDrawio
     end
 
     def test_macro_drawio_dmsf_unsaved
+      skip unless Redmine::Plugin.installed?(:redmine_dmsf)
+
       text = textilizable("{{drawio_dmsf(new-drawing.xml, hilight=#0000ff)}}")
       assert_equal "<p>«Please save content first»</p>", text
     end
 
     def test_macro_drawio_dmsf_with_existing_document
-      return unless Redmine::Plugin.installed?(:redmine_dmsf)
+      skip unless Redmine::Plugin.installed?(:redmine_dmsf)
 
       file_name = 'test.xml'
       prepare_dmsf_module(file_name)
-      
+
       assert_nothing_raised do
         result = exec_macro('drawio_dmsf', @obj, file_name, nil, hilight: '#0000ff')
         assert result.match(file_name), "Macro result does not match #{file_name}!"
@@ -67,13 +69,13 @@ module RedmineDrawio
       FileUtils.rm_rf DmsfFile.storage_path
       rescue StandardError => e
         puts e.message
-      ensure 
+      ensure
         Setting.clear_cache
     end
 
     private
 
-    def prepare_dmsf_module(file_name)      
+    def prepare_dmsf_module(file_name)
       @project1.enable_module! :dmsf
       Setting.plugin_redmine_dmsf['dmsf_storage_directory'] = File.join('files', ['dmsf'])
       FileUtils.cp_r File.join(File.expand_path('../../../../fixtures/files', __FILE__), '.'), DmsfFile.storage_path


### PR DESCRIPTION
Since Markdown is removed from RM 6.0 the patch adding wikitoolbar icons to the markdown editor needs to be restricted in order to load only for RM version 5.1 or lower.

Some tests are changed to load only if Redmine DMSF is installed. Currently, it does not support RM 6.0. This change will allow to test with success.